### PR TITLE
TST: add a test on mixed offsets for read_csv (#54245)

### DIFF
--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -2237,3 +2237,19 @@ def test_parse_dates_arrow_engine(all_parsers):
         }
     )
     tm.assert_frame_equal(result, expected)
+
+
+@xfail_pyarrow
+def test_from_csv_with_mixed_offsets(all_parsers):
+    parser = all_parsers
+    data = "a\n2020-01-01T00:00:00+01:00\n2020-01-01T00:00:00+00:00"
+    result = parser.read_csv(StringIO(data), parse_dates=["a"])["a"]
+    expected = Series(
+        [
+            Timestamp("2020-01-01 00:00:00+01:00"),
+            Timestamp("2020-01-01 00:00:00+00:00"),
+        ],
+        name="a",
+        index=[0, 1],
+    )
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
* TST: add a test on mixed offsets for read_csv

* change the location of the test

* add parser to the test