### PR TITLE
BUG: to_json not serializing non-nanosecond numpy dt64 correctly (#53757)

### DIFF
--- a/doc/source/whatsnew/v2.1.0.rst
+++ b/doc/source/whatsnew/v2.1.0.rst
@@ -538,6 +538,7 @@ I/O
 - Bug in :func:`read_sql` when reading multiple timezone aware columns with the same column name (:issue:`44421`)
 - Bug in :func:`read_xml` stripping whitespace in string data (:issue:`53811`)
 - Bug in :meth:`DataFrame.to_html` where ``colspace`` was incorrectly applied in case of multi index columns (:issue:`53885`)
+- Bug in :meth:`DataFrame.to_json` where :class:`DateTimeArray`/:class:`DateTimeIndex` with non nanosecond precision could not be serialized correctly (:issue:`53686`)
 - Bug when writing and reading empty Stata dta files where dtype information was lost (:issue:`46240`)
 - Bug where ``bz2`` was treated as a hard requirement (:issue:`53857`)
 

--- a/pandas/_libs/include/pandas/datetime/date_conversions.h
+++ b/pandas/_libs/include/pandas/datetime/date_conversions.h
@@ -18,7 +18,10 @@ int scaleNanosecToUnit(npy_int64 *value, NPY_DATETIMEUNIT unit);
 // up to precision `base` e.g. base="s" yields 2020-01-03T00:00:00Z
 // while base="ns" yields "2020-01-01T00:00:00.000000000Z"
 // len is mutated to save the length of the returned string
-char *int64ToIso(int64_t value, NPY_DATETIMEUNIT base, size_t *len);
+char *int64ToIso(int64_t value,
+                 NPY_DATETIMEUNIT valueUnit,
+                 NPY_DATETIMEUNIT base,
+                 size_t *len);
 
 // TODO(username): this function doesn't do a lot; should augment or
 // replace with scaleNanosecToUnit

--- a/pandas/_libs/include/pandas/datetime/pd_datetime.h
+++ b/pandas/_libs/include/pandas/datetime/pd_datetime.h
@@ -34,7 +34,7 @@ typedef struct {
   npy_datetime (*npy_datetimestruct_to_datetime)(NPY_DATETIMEUNIT,
                                                  const npy_datetimestruct *);
   int (*scaleNanosecToUnit)(npy_int64 *, NPY_DATETIMEUNIT);
-  char *(*int64ToIso)(int64_t, NPY_DATETIMEUNIT, size_t *);
+  char *(*int64ToIso)(int64_t, NPY_DATETIMEUNIT, NPY_DATETIMEUNIT, size_t *);
   npy_datetime (*NpyDateTimeToEpoch)(npy_datetime, NPY_DATETIMEUNIT);
   char *(*PyDateTimeToIso)(PyObject *, NPY_DATETIMEUNIT, size_t *);
   npy_datetime (*PyDateTimeToEpoch)(PyObject *, NPY_DATETIMEUNIT);
@@ -73,8 +73,8 @@ static PandasDateTime_CAPI *PandasDateTimeAPI = NULL;
                                                     (npy_datetimestruct))
 #define scaleNanosecToUnit(value, unit)                                        \
   PandasDateTimeAPI->scaleNanosecToUnit((value), (unit))
-#define int64ToIso(value, base, len)                                           \
-  PandasDateTimeAPI->int64ToIso((value), (base), (len))
+#define int64ToIso(value, valueUnit, base, len)                                \
+  PandasDateTimeAPI->int64ToIso((value), (valueUnit), (base), (len))
 #define NpyDateTimeToEpoch(dt, base)                                           \
   PandasDateTimeAPI->NpyDateTimeToEpoch((dt), (base))
 #define PyDateTimeToIso(obj, base, len)                                        \

--- a/pandas/_libs/src/datetime/date_conversions.c
+++ b/pandas/_libs/src/datetime/date_conversions.c
@@ -41,11 +41,14 @@ int scaleNanosecToUnit(npy_int64 *value, NPY_DATETIMEUNIT unit) {
 }
 
 /* Converts the int64_t representation of a datetime to ISO; mutates len */
-char *int64ToIso(int64_t value, NPY_DATETIMEUNIT base, size_t *len) {
+char *int64ToIso(int64_t value,
+                 NPY_DATETIMEUNIT valueUnit,
+                 NPY_DATETIMEUNIT base,
+                 size_t *len) {
     npy_datetimestruct dts;
     int ret_code;
 
-    pandas_datetime_to_datetimestruct(value, NPY_FR_ns, &dts);
+    pandas_datetime_to_datetimestruct(value, valueUnit, &dts);
 
     *len = (size_t)get_datetime_iso_8601_strlen(0, base);
     char *result = PyObject_Malloc(*len);


### PR DESCRIPTION
* BUG: to_json not serializing non-nanosecond numpy dt64 correctly

* fix tests

* change extraction mech

* fix object array case

* pre-commit

* address comments